### PR TITLE
✨ Feat: 탭 컨텐츠 박스 컴포넌트 추가 - 구조 변경 재시도

### DIFF
--- a/src/components/post/TabButtonBox.jsx
+++ b/src/components/post/TabButtonBox.jsx
@@ -1,35 +1,38 @@
-import { cva } from 'class-variance-authority';
-import PropTypes from 'prop-types';
+//TabButtonBox 컴포넌트
+
 import { useState } from 'react';
 import { cn } from '@/utils/style';
+import TabContents from './TabContents';
 
 // 탭 구성
 const tabs = [
-  { key: 'color', label: '컬러', content: '🎨 컬러 콘텐츠가 보여집니다' },
-  { key: 'image', label: '이미지', content: '🖼️ 이미지 콘텐츠가 보여집니다' },
+  { key: 'color', label: '컬러' },
+  { key: 'image', label: '이미지' },
 ];
 
 // 버튼 스타일 정의
-const tabButton = cva(
-  'flex items-center justify-center font-16-bold transition-all duration-200 rounded-md h-10 w-[118px] md:w-[122px]',
-  {
-    variants: {
-      active: {
-        true: 'border-2 border-purple-600 text-purple-700 bg-white',
-        false: 'border border-transparent text-black',
-      },
-    },
-    defaultVariants: {
-      active: false,
-    },
-  }
-);
+const tabButton = {
+  base: 'flex items-center justify-center font-16-bold transition-all duration-200 rounded-md h-10 w-[118px] md:w-[122px]',
+  active: 'border-2 border-purple-600 text-purple-700 bg-white',
+  inactive: 'border border-transparent text-black',
+};
 
 const TabButtonBox = ({ initialTab = 'color' }) => {
   const [activeTab, setActiveTab] = useState(initialTab);
 
+  // 선택된 요소 상태: { type: 'color' | 'image', index: number, value: string }
+  const [selected, setSelected] = useState(null);
+
+  const handleSelect = (type, index, value) => {
+    if (selected?.type === type && selected?.index === index) {
+      setSelected(null); // 다시 클릭하면 해제
+    } else {
+      setSelected({ type, index, value }); // 새로운 선택
+    }
+  };
+
   return (
-    <div className="px-4 py-10">
+    <div className="mx-auto w-full max-w-[720px] py-10">
       {/* 탭 버튼 그룹 */}
       <div className="flex w-fit justify-center rounded-lg bg-gray-100">
         {tabs.map(({ key, label }) => {
@@ -37,7 +40,11 @@ const TabButtonBox = ({ initialTab = 'color' }) => {
             <button
               key={key}
               onClick={() => setActiveTab(key)}
-              className={cn(tabButton({ active: activeTab === key }))}>
+              className={cn(
+                tabButton.base,
+                activeTab === key ? tabButton.active : tabButton.inactive
+              )}
+              type="button">
               {label}
             </button>
           );
@@ -46,14 +53,14 @@ const TabButtonBox = ({ initialTab = 'color' }) => {
 
       {/* 선택된 탭 콘텐츠 */}
       <div className="mt-10">
-        {tabs.find((tab) => tab.key === activeTab)?.content}
+        <TabContents
+          activeTab={activeTab}
+          selected={selected}
+          onSelect={handleSelect}
+        />
       </div>
     </div>
   );
-};
-
-TabButtonBox.propTypes = {
-  initialTab: PropTypes.oneOf(['color', 'image']),
 };
 
 export default TabButtonBox;

--- a/src/components/post/TabButtonBox.jsx
+++ b/src/components/post/TabButtonBox.jsx
@@ -1,31 +1,62 @@
-//TabButtonBox 컴포넌트
-
 import { useState } from 'react';
 import { cn } from '@/utils/style';
 import TabContents from './TabContents';
 
-// 탭 구성
+/**
+ * 탭 구성 정보
+ * @type {{ key: 'color'|'image', label: string }[]}
+ */
 const tabs = [
   { key: 'color', label: '컬러' },
   { key: 'image', label: '이미지' },
 ];
 
-// 버튼 스타일 정의
+/**
+ * 탭 버튼 스타일 정의
+ */
 const tabButton = {
   base: 'flex items-center justify-center font-16-bold transition-all duration-200 rounded-md h-10 w-[118px] md:w-[122px]',
   active: 'border-2 border-purple-600 text-purple-700 bg-white',
   inactive: 'border border-transparent text-black',
 };
 
+/**
+ * TabButtonBox 컴포넌트 props 정의
+ * @typedef {Object} TabButtonBoxProps
+ * @property {'color'|'image'} [initialTab='color'] - 초기 활성화 탭
+ */
+
+/**
+ * 탭 버튼과 해당 탭 콘텐츠(TabContents)를 렌더링하는 컴포넌트
+ *
+ * @param {TabButtonBoxProps} props
+ * @returns {JSX.Element}
+ *
+ * @example
+ * <TabButtonBox initialTab="image" />
+ */
 const TabButtonBox = ({ initialTab = 'color' }) => {
+  /**
+   * 현재 활성화된 탭 상태
+   * @type {'color'|'image'}
+   */
   const [activeTab, setActiveTab] = useState(initialTab);
 
-  // 선택된 요소 상태: { type: 'color' | 'image', index: number, value: string }
+  /**
+   * 선택된 요소 상태
+   * @type {{ type: 'color'|'image', index: number, value: string } | null}
+   */
   const [selected, setSelected] = useState(null);
 
+  /**
+   * 항목 선택 핸들러
+   * @param {'color'|'image'} type - 선택 항목 타입
+   * @param {number} index - 선택 항목 인덱스
+   * @param {string} value - 선택 항목 값 (컬러 클래스 또는 이미지 URL)
+   */
   const handleSelect = (type, index, value) => {
     if (selected?.type === type && selected?.index === index) {
-      setSelected(null); // 다시 클릭하면 해제
+      setSelected(null); // 다시 클릭하면 선택 해제
     } else {
       setSelected({ type, index, value }); // 새로운 선택
     }

--- a/src/components/post/TabContents.jsx
+++ b/src/components/post/TabContents.jsx
@@ -3,18 +3,59 @@ import { api } from '@/apis/axios.js';
 import { cn } from '@/utils/style';
 import SelectItem from './TabSelectItem';
 
+/**
+ * 색상 선택용 TailwindCSS 클래스 배열
+ * @type {string[]}
+ */
 const colorChips = [
-  'bg-orange-200',
+  'bg-beige-200',
   'bg-purple-200',
   'bg-blue-200',
   'bg-green-200',
 ];
 
+/**
+ * 이미지 데이터 객체 타입
+ * @typedef {Object} ImageData
+ * @property {string} original - 원본 이미지 URL
+ * @property {string} thumbnail - 썸네일 이미지 URL (200x200)
+ */
+
+/**
+ * TabContents 컴포넌트 props 정의
+ * @typedef {Object} TabContentsProps
+ * @property {'color'|'image'} activeTab - 현재 활성화된 탭
+ * @property {{ type: 'color'|'image', index: number } | null} selected - 현재 선택된 항목 정보
+ * @property {(type: 'color'|'image', index: number, value: string) => void} onSelect - 항목 선택 시 호출되는 콜백
+ */
+
+/**
+ * 탭에 따라 색상 또는 이미지 선택 UI를 렌더링하는 컴포넌트
+ *
+ * @param {TabContentsProps} props
+ * @returns {JSX.Element}
+ *
+ * @example
+ * <TabContents
+ *   activeTab="color"
+ *   selected={{ type: 'color', index: 0 }}
+ *   onSelect={(type, idx, value) => console.log(type, idx, value)}
+ * />
+ */
 const TabContents = ({ activeTab, selected, onSelect }) => {
-  const [imageUrls, setImageUrls] = useState([]); // [{ original, thumbnail }]
+  /**
+   * API에서 가져온 이미지 URL 목록
+   * @type {ImageData[]}
+   */
+  const [imageUrls, setImageUrls] = useState([]);
+
+  /** 로딩 상태 */
   const [loading, setLoading] = useState(false);
+
+  /** 에러 상태 */
   const [error, setError] = useState(null);
 
+  // 이미지 탭 활성화 시 API 호출
   useEffect(() => {
     if (activeTab === 'image' && imageUrls.length === 0) {
       const controller = new AbortController();
@@ -27,7 +68,7 @@ const TabContents = ({ activeTab, selected, onSelect }) => {
           const originals = res.data.imageUrls || [];
           const mapped = originals.map((url) => ({
             original: url,
-            thumbnail: url.replace(/\/\d+\/\d+$/, '/200/200'), // 이미지 썸네일: 원본 크기에서 200x200으로 변경
+            thumbnail: url.replace(/\/\d+\/\d+$/, '/200/200'), // 썸네일 변환
           }));
           setImageUrls(mapped);
         })
@@ -39,13 +80,14 @@ const TabContents = ({ activeTab, selected, onSelect }) => {
         })
         .finally(() => setLoading(false));
 
-      return () => controller.abort();
+      return () => controller.abort(); // 컴포넌트 언마운트 시 요청 취소
     }
   }, [activeTab]);
 
   if (activeTab === 'image' && loading) {
     return <div className="py-20 text-center">이미지 불러오는 중...</div>;
   }
+
   if (error) {
     return <div className="py-20 text-center text-red-500">{error}</div>;
   }
@@ -56,6 +98,7 @@ const TabContents = ({ activeTab, selected, onSelect }) => {
         colorChips.map((color, idx) => {
           const isSelected =
             selected?.type === 'color' && selected?.index === idx;
+
           return (
             <SelectItem
               key={`color-${idx}`}
@@ -70,11 +113,11 @@ const TabContents = ({ activeTab, selected, onSelect }) => {
         imageUrls.map((img, idx) => {
           const isSelected =
             selected?.type === 'image' && selected?.index === idx;
+
           return (
             <SelectItem
               key={`image-${idx}`}
               isSelected={isSelected}
-              // 원본 URL을 onSelect로 넘김
               onClick={() => onSelect('image', idx, img.original)}>
               <img
                 src={img.thumbnail}

--- a/src/components/post/TabContents.jsx
+++ b/src/components/post/TabContents.jsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/apis/axios.js';
+import SelectItem from './TabSelectItem';
+
+const colorChips = [
+  'bg-orange-200',
+  'bg-purple-200',
+  'bg-blue-200',
+  'bg-green-200',
+];
+
+const TabContents = ({ activeTab, selected, onSelect }) => {
+  const [imageUrls, setImageUrls] = useState([]); // [{ original, thumbnail }]
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (activeTab === 'image' && imageUrls.length === 0) {
+      const controller = new AbortController();
+      setLoading(true);
+      setError(null);
+
+      api
+        .get('/background-images/', { signal: controller.signal })
+        .then((res) => {
+          const originals = res.data.imageUrls || [];
+          const mapped = originals.map((url) => ({
+            original: url,
+            thumbnail: url.replace(/\/\d+\/\d+$/, '/200/200'),
+          }));
+          setImageUrls(mapped);
+        })
+        .catch((err) => {
+          if (err.name !== 'CanceledError') {
+            console.error('이미지 API 호출 실패:', err);
+            setError('이미지를 불러오는 데 실패했습니다.');
+          }
+        })
+        .finally(() => setLoading(false));
+
+      return () => controller.abort();
+    }
+  }, [activeTab]);
+
+  if (activeTab === 'image' && loading) {
+    return <div className="py-20 text-center">이미지 불러오는 중...</div>;
+  }
+  if (error) {
+    return <div className="py-20 text-center text-red-500">{error}</div>;
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4 md:mx-auto md:w-[720px]">
+      {activeTab === 'color' &&
+        colorChips.map((color, idx) => {
+          const isSelected =
+            selected?.type === 'color' && selected?.index === idx;
+          return (
+            <SelectItem
+              key={`color-${idx}`}
+              isSelected={isSelected}
+              onClick={() => onSelect('color', idx, color)}
+              className={color}
+            />
+          );
+        })}
+
+      {activeTab === 'image' &&
+        imageUrls.map((img, idx) => {
+          const isSelected =
+            selected?.type === 'image' && selected?.index === idx;
+          return (
+            <SelectItem
+              key={`image-${idx}`}
+              isSelected={isSelected}
+              // 👉 원본 URL을 onSelect로 넘김
+              onClick={() => onSelect('image', idx, img.original)}>
+              <img
+                src={img.thumbnail}
+                alt={`배경 이미지-${idx}`}
+                className={`h-full w-full object-cover transition-opacity duration-200 ${
+                  isSelected ? 'opacity-70' : 'opacity-100'
+                }`}
+                loading="lazy"
+              />
+            </SelectItem>
+          );
+        })}
+    </div>
+  );
+};
+
+export default TabContents;

--- a/src/components/post/TabContents.jsx
+++ b/src/components/post/TabContents.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '@/apis/axios.js';
+import { cn } from '@/utils/style';
 import SelectItem from './TabSelectItem';
 
 const colorChips = [
@@ -26,7 +27,7 @@ const TabContents = ({ activeTab, selected, onSelect }) => {
           const originals = res.data.imageUrls || [];
           const mapped = originals.map((url) => ({
             original: url,
-            thumbnail: url.replace(/\/\d+\/\d+$/, '/200/200'),
+            thumbnail: url.replace(/\/\d+\/\d+$/, '/200/200'), // 이미지 썸네일: 원본 크기에서 200x200으로 변경
           }));
           setImageUrls(mapped);
         })
@@ -73,14 +74,15 @@ const TabContents = ({ activeTab, selected, onSelect }) => {
             <SelectItem
               key={`image-${idx}`}
               isSelected={isSelected}
-              // 👉 원본 URL을 onSelect로 넘김
+              // 원본 URL을 onSelect로 넘김
               onClick={() => onSelect('image', idx, img.original)}>
               <img
                 src={img.thumbnail}
                 alt={`배경 이미지-${idx}`}
-                className={`h-full w-full object-cover transition-opacity duration-200 ${
+                className={cn(
+                  'h-full w-full object-cover transition-opacity duration-200',
                   isSelected ? 'opacity-70' : 'opacity-100'
-                }`}
+                )}
                 loading="lazy"
               />
             </SelectItem>

--- a/src/components/post/TabSelectItem.jsx
+++ b/src/components/post/TabSelectItem.jsx
@@ -1,0 +1,19 @@
+import icons from '@/assets/icons/icons';
+
+const SelectItem = ({ isSelected, onClick, className, children }) => {
+  return (
+    <div
+      onClick={onClick}
+      className={`relative flex aspect-square w-full cursor-pointer items-center justify-center overflow-hidden rounded-[16px] border border-black/10 ${className} transition-transform hover:scale-[1.03]`}>
+      {children}
+
+      {isSelected && (
+        <div className="absolute flex h-10 w-10 items-center justify-center rounded-full bg-gray-500">
+          <icons.CheckIcon width={24} height={24} className="text-white" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SelectItem;

--- a/src/components/post/TabSelectItem.jsx
+++ b/src/components/post/TabSelectItem.jsx
@@ -1,10 +1,21 @@
 import icons from '@/assets/icons/icons';
+import { cn } from '@/utils/style';
 
 const SelectItem = ({ isSelected, onClick, className, children }) => {
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
-      className={`relative flex aspect-square w-full cursor-pointer items-center justify-center overflow-hidden rounded-[16px] border border-black/10 ${className} transition-transform hover:scale-[1.03]`}>
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          onClick();
+        }
+      }}
+      className={cn(
+        'relative flex aspect-square w-full cursor-pointer items-center justify-center overflow-hidden rounded-[16px] border border-black/10 transition-transform hover:scale-[1.03]',
+        className
+      )}>
       {children}
 
       {isSelected && (

--- a/src/components/post/TabSelectItem.jsx
+++ b/src/components/post/TabSelectItem.jsx
@@ -1,6 +1,33 @@
 import icons from '@/assets/icons/icons';
 import { cn } from '@/utils/style';
 
+/**
+ * SelectItem 컴포넌트 props 정의
+ * @typedef {Object} SelectItemProps
+ * @property {boolean} isSelected - 현재 선택 여부
+ * @property {() => void} onClick - 클릭 시 호출되는 콜백
+ * @property {string} [className] - 추가적인 TailwindCSS 클래스
+ * @property {React.ReactNode} [children] - 내부에 렌더링할 콘텐츠
+ */
+
+/**
+ * 선택 가능한 아이템 컴포넌트
+ * - 클릭 시 선택 상태를 부모 컴포넌트로 전달
+ * - 키보드 Enter 또는 Space 키로도 선택 가능 (접근성 지원)
+ * - 선택된 경우 중앙에 체크 아이콘 표시
+ *
+ * @param {SelectItemProps} props
+ * @returns {JSX.Element}
+ *
+ * @example
+ * <SelectItem
+ *   isSelected={true}
+ *   onClick={() => console.log('클릭됨')}
+ *   className="bg-blue-200"
+ * >
+ *   <div>아이템 내용</div>
+ * </SelectItem>
+ */
 const SelectItem = ({ isSelected, onClick, className, children }) => {
   return (
     <div

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -1,4 +1,5 @@
 import TextInput from '@/components/common/TextInput';
+import TabButtonBox from '@/components/post/TabButtonBox';
 import { useInput } from '@/hooks/useInput';
 
 const Post = () => {
@@ -19,6 +20,7 @@ const Post = () => {
         placeholder="받는 사람 이름을 입력해 주세요"
         {...toInput}
       />
+      <TabButtonBox />
     </div>
   );
 };


### PR DESCRIPTION
## 🔗 이슈 번호 #60

- close #60


## ✨ 작업한 내용

탭 컨텐츠 내용 구현
탭 버튼과 연동
컬러칩에 들어가는 이미지 로딩 시 축소 작업
탭 컨텐츠에서 선택된 컬러칩 정보 받아놓기
-> 롤링 리스트 페이지 배경에 데이터 전달을 위함

## 💡 참고사항

이전 pr 메인 풀 받다 충돌이 일어나
이전 pr을 닫고 다시 연 pr입니다 
